### PR TITLE
Avoid adding a nil connection

### DIFF
--- a/gmetric/gmetric.go
+++ b/gmetric/gmetric.go
@@ -99,7 +99,7 @@ func (g *Gmetric) SendMetricPackets(name string, value string, metricType uint32
 }
 
 func (g *Gmetric) OpenConnections() []*net.UDPConn {
-	conn := make([]*net.UDPConn, 1)
+	conn := make([]*net.UDPConn, 0)
 	for i := 0; i < len(g.Servers); i++ {
 		raddr := &net.UDPAddr{IP: g.Servers[i].Server, Port: g.Servers[i].Port}
 		udp, err := net.DialUDP("udp", nil, raddr)


### PR DESCRIPTION
OpenConnections leaves a nil net.UDPConn at the beginning of the returned connections. This used to not cause problems but recently (perhaps since using a Go newer than 1.1) it's causing a panic in SendMetricPackets while doing conn[i].Write(m_buf).
