### PR TITLE
Fix sending to uninitialized servers

### DIFF
--- a/gmetric/gmetric.go
+++ b/gmetric/gmetric.go
@@ -48,19 +48,16 @@ type GmetricServer struct {
 
 type Gmetric struct {
 	Servers    []GmetricServer
-	NumServers int
 	Host       string
 	Spoof      string
 }
 
 func (g *Gmetric) AddServer(s GmetricServer) {
-	if g.NumServers == 0 {
+	if g.Servers == nil {
 		// Initialize
-		g.Servers = make([]GmetricServer, MAX_GMETRIC_SERVERS)
-		g.NumServers = 0
+		g.Servers = make([]GmetricServer, 0, MAX_GMETRIC_SERVERS)
 	}
-	g.Servers[g.NumServers] = s
-	g.NumServers++
+	g.Servers = append(g.Servers, s)
 }
 
 func (g *Gmetric) SetLogger(l *syslog.Writer) {


### PR DESCRIPTION
Previously, OpenConnections created a UDPConn for each entry in g.Servers, but
g.Servers is preallocated to contain MAX_GMETRIC_SERVERS (zeroed) entries. This
winds up sending packets to :0 for any entry not overwritten by AddServer,
leading to a bunch of ICMP reject traffic.

This fix makes the initial allocation to be a capacity of MAX_GMETRIC_SERVERS
instead of len and uses append to add new entries. This obviates the need for
tracking NumServers as well.
